### PR TITLE
Sdk에서 에러 수집 및 서버에 에러 전송

### DIFF
--- a/__test__/package-lock.json
+++ b/__test__/package-lock.json
@@ -1612,6 +1612,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3220,6 +3230,13 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4593,6 +4610,13 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6841,7 +6865,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -7113,7 +7141,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/__test__/package.json
+++ b/__test__/package.json
@@ -14,5 +14,6 @@
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/__test__/package.json
+++ b/__test__/package.json
@@ -14,6 +14,5 @@
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/__test__/src/index.html
+++ b/__test__/src/index.html
@@ -4,6 +4,7 @@
     <title>테스트</title>
   </head>
   <body>
-    <!-- <script type=></script> -->
+    <button id="error">Fire Error</button>
+    <button id="promise">Fire Unhandled Promise</button>
   </body>
 </html>

--- a/__test__/src/index.js
+++ b/__test__/src/index.js
@@ -1,3 +1,29 @@
-import bundle from '../../dist/bundle';
+import Panopticon from '../../dist/bundle';
 
-bundle();
+Panopticon.init();
+
+const errorMaker = () => {
+  throw new Error('error maker made this');
+};
+
+const errorCountdown = (num) => {
+  if (num > 0) {
+    errorCountdown(num - 1);
+  } else {
+    errorMaker();
+  }
+};
+
+const errorButton = document.querySelector('#error');
+errorButton.addEventListener('click', () => {
+  // noUndefinedFn();
+  // throw new Error('Error button clicked');
+  errorCountdown(10);
+});
+
+const unhandledPromiseButton = document.querySelector('#promise');
+unhandledPromiseButton.addEventListener('click', () => {
+  new Promise(() => {
+    throw new Error('Unhandled promise rejection!');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,6 +693,11 @@
       "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1464,6 +1469,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -4228,6 +4241,11 @@
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -671,6 +671,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2079,6 +2089,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3125,6 +3142,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4935,7 +4959,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "webpack": "^4.44.2"
   },
   "dependencies": {
+    "bowser": "^2.11.0",
+    "error-stack-parser": "^2.0.6",
     "typescript": "^4.0.5",
     "webpack-cli": "^4.2.0"
   }

--- a/src/apis/sendError.ts
+++ b/src/apis/sendError.ts
@@ -1,0 +1,12 @@
+import { IPayload } from '../handlers/type';
+
+export default async (payload: IPayload, dsn: string): Promise<Response> => {
+  const response = await fetch(dsn, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  return response;
+};

--- a/src/apis/sendError.ts
+++ b/src/apis/sendError.ts
@@ -1,12 +1,17 @@
 import { IPayload } from '../handlers/type';
 
-export default async (payload: IPayload, dsn: string): Promise<Response> => {
-  const response = await fetch(dsn, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-  return response;
+export default async (payload: IPayload, dsn: string): Promise<Response | undefined> => {
+  try {
+    const response = await fetch(dsn, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    return response;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
 };

--- a/src/clickHandler.ts
+++ b/src/clickHandler.ts
@@ -1,5 +1,0 @@
-export default () => {
-  window.addEventListener('click', () => {
-    console.log('bye npm test!');
-  });
-};

--- a/src/handlers/onError/index.ts
+++ b/src/handlers/onError/index.ts
@@ -1,9 +1,9 @@
 import { name, version } from '../../../package.json';
 import { IError, IPayload } from '../type';
+import sendError from '../../apis/sendError';
 
-const onErrorHandler = (): void => {
+const onErrorHandler = (dsn: string): void => {
   window.onerror = (message, source, line, column, error) => {
-    console.log(error);
     const errorObject: IError = {
       message,
       stack: error?.stack,
@@ -16,6 +16,7 @@ const onErrorHandler = (): void => {
       },
       error: errorObject,
     };
+    sendError(payload, dsn);
   };
 };
 

--- a/src/handlers/onError/index.ts
+++ b/src/handlers/onError/index.ts
@@ -1,0 +1,22 @@
+import { name, version } from '../../../package.json';
+import { IError, IPayload } from '../type';
+
+const onErrorHandler = (): void => {
+  window.onerror = (message, source, line, column, error) => {
+    console.log(error);
+    const errorObject: IError = {
+      message,
+      stack: error?.stack,
+    };
+
+    const payload: IPayload = {
+      sdk: {
+        name,
+        version,
+      },
+      error: errorObject,
+    };
+  };
+};
+
+export default onErrorHandler;

--- a/src/handlers/onError/index.ts
+++ b/src/handlers/onError/index.ts
@@ -1,20 +1,23 @@
 import { name, version } from '../../../package.json';
-import { IError, IPayload } from '../type';
+import { IPayload, IStack, IMeta } from '../type';
 import sendError from '../../apis/sendError';
+import { parseStack, parseMeta } from '../../utils/parser';
 
 const onErrorHandler = (dsn: string): void => {
   window.onerror = (message, source, line, column, error) => {
-    const errorObject: IError = {
-      message,
-      stack: error?.stack,
-    };
-
+    if (!error) return;
+    parseStack(error);
+    const stack: IStack[] = parseStack(error);
+    const meta: IMeta = parseMeta();
     const payload: IPayload = {
+      message: error.message || '',
       sdk: {
         name,
         version,
       },
-      error: errorObject,
+      stack,
+      occuredAt: new Date().toString(),
+      meta,
     };
     sendError(payload, dsn);
   };

--- a/src/handlers/onUnhandledRejection/index.ts
+++ b/src/handlers/onUnhandledRejection/index.ts
@@ -1,7 +1,8 @@
 import { name, version } from '../../../package.json';
 import { IError, IPayload } from '../type';
+import sendError from '../../apis/sendError';
 
-const onUnhandledRejection = (): void => {
+const onUnhandledRejection = (dsn: string): void => {
   window.onunhandledrejection = (rejection: PromiseRejectionEvent) => {
     rejection.promise.catch((error: Error) => {
       const errorObject: IError = {
@@ -16,6 +17,7 @@ const onUnhandledRejection = (): void => {
         },
         error: errorObject,
       };
+      sendError(payload, dsn);
     });
   };
 };

--- a/src/handlers/onUnhandledRejection/index.ts
+++ b/src/handlers/onUnhandledRejection/index.ts
@@ -1,0 +1,23 @@
+import { name, version } from '../../../package.json';
+import { IError, IPayload } from '../type';
+
+const onUnhandledRejection = (): void => {
+  window.onunhandledrejection = (rejection: PromiseRejectionEvent) => {
+    rejection.promise.catch((error: Error) => {
+      const errorObject: IError = {
+        message: error.message,
+        stack: error.stack,
+      };
+
+      const payload: IPayload = {
+        sdk: {
+          name,
+          version,
+        },
+        error: errorObject,
+      };
+    });
+  };
+};
+
+export default onUnhandledRejection;

--- a/src/handlers/onUnhandledRejection/index.ts
+++ b/src/handlers/onUnhandledRejection/index.ts
@@ -1,25 +1,27 @@
 import { name, version } from '../../../package.json';
-import { IError, IPayload } from '../type';
+import { IPayload, IStack, IMeta } from '../type';
 import sendError from '../../apis/sendError';
+import { parseStack, parseMeta } from '../../utils/parser';
 
 const onUnhandledRejection = (dsn: string): void => {
   window.onunhandledrejection = (rejection: PromiseRejectionEvent) => {
     rejection.promise.catch((error: Error) => {
-      const errorObject: IError = {
-        message: error.message,
-        stack: error.stack,
-      };
-
+      if (!error) return;
+      parseStack(error);
+      const stack: IStack[] = parseStack(error);
+      const meta: IMeta = parseMeta();
       const payload: IPayload = {
+        message: error.message || '',
         sdk: {
           name,
           version,
         },
-        error: errorObject,
+        stack,
+        occuredAt: new Date().toString(),
+        meta,
       };
       sendError(payload, dsn);
     });
   };
 };
-
 export default onUnhandledRejection;

--- a/src/handlers/type.ts
+++ b/src/handlers/type.ts
@@ -1,9 +1,25 @@
-export interface IError {
-  message: string | Event;
-  stack: string | undefined;
+export interface IPayload {
+  message: string;
+  stack: IStack[];
+  occuredAt: Date;
+  sdk: Information;
+  meta: IMeta;
 }
 
-export interface IPayload {
-  sdk: { name: string; version: string };
-  error: IError;
+interface IMeta {
+  browser: Information;
+  os: Information;
+  url: string;
+  ip: string;
+}
+interface IStack {
+  columnNo: string;
+  lineNo: string;
+  function: string;
+  filename: string;
+}
+
+interface Information {
+  name: string;
+  version: string;
 }

--- a/src/handlers/type.ts
+++ b/src/handlers/type.ts
@@ -1,22 +1,22 @@
 export interface IPayload {
   message: string;
   stack: IStack[];
-  occuredAt: Date;
+  occuredAt: string;
   sdk: Information;
   meta: IMeta;
 }
 
-interface IMeta {
-  browser: Information;
-  os: Information;
-  url: string;
-  ip: string;
-}
-interface IStack {
+export interface IStack {
   columnNo: string;
   lineNo: string;
   function: string;
   filename: string;
+}
+
+export interface IMeta {
+  browser: Information;
+  os: Information;
+  url: string;
 }
 
 interface Information {

--- a/src/handlers/type.ts
+++ b/src/handlers/type.ts
@@ -1,0 +1,9 @@
+export interface IError {
+  message: string | Event;
+  stack: string | undefined;
+}
+
+export interface IPayload {
+  sdk: { name: string; version: string };
+  error: IError;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
-import clickHandler from './clickHandler';
+import onErrorHandler from './handlers/onError';
+import onUnhandledRejection from './handlers/onUnhandledRejection';
 
-export default clickHandler;
+const Panopticon = {
+  init: (): void => {
+    onErrorHandler();
+    onUnhandledRejection();
+  },
+};
+
+export default Panopticon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import onErrorHandler from './handlers/onError';
 import onUnhandledRejection from './handlers/onUnhandledRejection';
 
 const Panopticon = {
-  init: (): void => {
-    onErrorHandler();
-    onUnhandledRejection();
+  init: (dsn: string): void => {
+    onErrorHandler(dsn);
+    onUnhandledRejection(dsn);
   },
 };
 

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,0 +1,35 @@
+import * as Bowser from 'bowser';
+import * as ErrorStackParser from 'error-stack-parser';
+import { IStack, IMeta } from '../handlers/type';
+
+// stack
+export const parseStack = (error: Error): IStack[] => {
+  const parsedDataList = ErrorStackParser.parse(error);
+  const parsedStackList: IStack[] = parsedDataList.map((data: ErrorStackParser.StackFrame) => {
+    return {
+      columnNo: String(data.columnNumber) || '',
+      lineNo: String(data.lineNumber) || '',
+      filename: data.fileName || '',
+      function: data.functionName || '',
+    };
+  });
+
+  return parsedStackList;
+};
+
+// meta
+export const parseMeta = (): IMeta => {
+  const { browser, os } = Bowser.parse(window.navigator.userAgent);
+  const metaData: IMeta = {
+    browser: {
+      name: browser.name || '',
+      version: browser.version || '',
+    },
+    os: {
+      name: os.name || '',
+      version: os.versionName || '',
+    },
+    url: window.location.href,
+  };
+  return metaData;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "lib": ["ES2015", "dom"]
   },
   "exclude": ["dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,13 @@
     /* Basic Options */
     "target": "es5",
     "module": "es6",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
   "exclude": ["dist"]
 }


### PR DESCRIPTION
### 구현의도

- Sdk에서 에러 수집 및 서버 에러 전송
- window객체의 onerror, onunhandledrejection을 이용한 에러 수집 및 전송

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- bowser : navigator 객체에서 meta 데이터 파싱
- error-stack-parser : error 객체에서 stack 파싱

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- sdk에서 에러를 보내는데, server가 통신이 안되는 경우 무한루프에 빠짐.
