### PR TITLE
수동 에러 전송 기능 

### DIFF
--- a/__test__/src/index.html
+++ b/__test__/src/index.html
@@ -18,6 +18,7 @@
         <button id='syntax-error'>Fire SyntaxError</button>
         <button id='type-error'>Fire TypeError</button>
         <button id='uri-error'>Fire URIError</button>
+        <button id='manual-error'>Manual Send Error </button>
     </div>
   </body>
 </html>

--- a/__test__/src/index.js
+++ b/__test__/src/index.js
@@ -1,6 +1,6 @@
 import Panopticon from '../../dist/bundle';
 
-const dsn = 'http://panopticon-dev.gq/api/issue'
+const dsn = 'http://panopticon.gq/api/crime/5fcee5757395142ba8e1cbf1';
 
 Panopticon.init(dsn);
 
@@ -70,8 +70,17 @@ typeErrorButton.addEventListener('click', () => {
 // URIError
 const uriErrorButton = document.querySelector('#uri-error');
 uriErrorButton.addEventListener('click', () => {
-  const uri = 'https://boostcamp.com/?한국어=쿼리'
+  const uri = 'https://boostcamp.com/?한국어=쿼리';
   const encoded = encodeURI(uri);
   const malformedUri = encoded.slice(20, 30);
   const decoded = decodeURI(malformedUri);
+});
+
+const manualErrorButton = document.querySelector('#manual-error');
+manualErrorButton.addEventListener('click', () => {
+  try {
+    throw new Error("Maybe I'll be caught by try-catch");
+  } catch (err) {
+    Panopticon.send(err);
+  }
 });

--- a/src/handlers/onManualError/index.ts
+++ b/src/handlers/onManualError/index.ts
@@ -1,0 +1,25 @@
+import { name, version } from '../../../package.json';
+import { IPayload, IStack, IMeta } from '../type';
+import sendError from '../../apis/sendError';
+import { parseStack, parseErrorType, parseMeta } from '../../utils/parser';
+
+const onManualError = (dsn: string, error: Error): void => {
+  if (!error) return;
+  const stack: IStack[] = parseStack(error);
+  const errorType = parseErrorType(error);
+  const meta: IMeta = parseMeta();
+  const payload: IPayload = {
+    type: errorType,
+    message: error.message || '',
+    sdk: {
+      name,
+      version,
+    },
+    stack,
+    occuredAt: new Date().toString(),
+    meta,
+  };
+  sendError(payload, dsn);
+};
+
+export default onManualError;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,24 @@
 import onErrorHandler from './handlers/onError';
 import onUnhandledRejection from './handlers/onUnhandledRejection';
+import onManualError from './handlers/onManualError';
 
-const Panopticon = {
-  init: (dsn: string): void => {
-    onErrorHandler(dsn);
-    onUnhandledRejection(dsn);
-  },
+const PanopticonClass = class {
+  DSN: string;
+
+  constructor() {
+    this.DSN = '';
+  }
+
+  init = (dsn: string) => {
+    this.DSN = dsn;
+    onErrorHandler(this.DSN);
+    onUnhandledRejection(this.DSN);
+  };
+
+  send = (err: Error) => {
+    onManualError(this.DSN, err);
+  };
 };
+const Panopticon = new PanopticonClass();
 
 export default Panopticon;


### PR DESCRIPTION
### 구현의도
- try-catch 구문으로 처리된 에러를 판옵티콘으로 전송할 수 있도록 했습니다.
- 객체형식으로 변환 하여 객체 내부에 dsn을 저장하도록 변경했습니다. 
- 에러 파싱자체는 기존의 에러 파싱 함수 코드를 사용했습니다.

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 보내는 crime에 handled/unhandled 를 표시할 수 있는 속성을 추가해야 할것같습니다.
- 또한 handled의 여부는 이슈 구분의 기준점이 되어도 좋을것같습니다.
