### PR TITLE
init 함수 분리, init시 방문자 체크를 위한 요청

### DIFF
--- a/src/apis/sendEngagement.ts
+++ b/src/apis/sendEngagement.ts
@@ -1,7 +1,7 @@
 export default (dsn: string): void => {
   try {
     if (dsn === '') return;
-    fetch(`${dsn}/engagement`, {
+    fetch(`${dsn}/visits`, {
       method: 'POST',
     });
   } catch (error) {

--- a/src/apis/sendEngagement.ts
+++ b/src/apis/sendEngagement.ts
@@ -1,0 +1,10 @@
+export default (dsn: string): void => {
+  try {
+    if (dsn === '') return;
+    fetch(`${dsn}/engagement`, {
+      method: 'POST',
+    });
+  } catch (error) {
+    // do nothing
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import sendEngagement from './apis/sendEngagement';
 import onErrorHandler from './handlers/onError';
 import onUnhandledRejection from './handlers/onUnhandledRejection';
 import onManualError from './handlers/onManualError';
@@ -14,6 +15,11 @@ const PanopticonClass = class {
   }
 
   init = (dsn: string) => {
+    this.setDSN(dsn);
+    sendEngagement(dsn);
+  };
+
+  setDSN = (dsn: string) => {
     this.DSN = dsn;
     onErrorHandler(this.DSN, this.config);
     onUnhandledRejection(this.DSN, this.config);
@@ -25,12 +31,12 @@ const PanopticonClass = class {
 
   setTag = (key: string, value: string) => {
     this.config.customTag.push({ key, value });
-    this.init(this.DSN);
+    this.setDSN(this.DSN);
   };
 
   setUser = (_user: string) => {
     this.config.user = _user;
-    this.init(this.DSN);
+    this.setDSN(this.DSN);
   };
 };
 const Panopticon = new PanopticonClass();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import sendEngagement from './apis/sendEngagement';
+import sendVisits from './apis/sendEngagement';
 import onErrorHandler from './handlers/onError';
 import onUnhandledRejection from './handlers/onUnhandledRejection';
 import onManualError from './handlers/onManualError';
@@ -16,7 +16,7 @@ const PanopticonClass = class {
 
   init = (dsn: string) => {
     this.setDSN(dsn);
-    sendEngagement(dsn);
+    sendVisits(dsn);
   };
 
   setDSN = (dsn: string) => {


### PR DESCRIPTION
### 구현의도
- init 함수 분리
  `init`의 의미 자체가 1번만 실행되는것이므로 `setTag`, `setUser`에서 필요한 로직을 `setDSN` 함수를 만들어서 분리
- init 시 서버로 요청
  `init` 호출 시 사용자 체크를 위해 post 요청을 보내는 기능 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
