### PR TITLE
캐싱 기능 추가, visits api 수정

### DIFF
--- a/src/apis/sendError.ts
+++ b/src/apis/sendError.ts
@@ -1,16 +1,16 @@
 import { IPayload } from '../handlers/type';
+import saveCrime from '../caching/saveCrime';
 
-export default async (payload: IPayload, dsn: string): Promise<Response | undefined> => {
+export default async (payload: IPayload, dsn: string): Promise<void> => {
   try {
-    const response = await fetch(`${dsn}/crime`, {
+    await fetch(`${dsn}/crime`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
     });
-    return response;
   } catch (error) {
-    return undefined;
+    saveCrime(payload);
   }
 };

--- a/src/apis/sendError.ts
+++ b/src/apis/sendError.ts
@@ -1,5 +1,6 @@
 import { IPayload } from '../handlers/type';
 import saveCrime from '../caching/saveCrime';
+import sendCached from '../caching/sendCached';
 
 export default async (payload: IPayload, dsn: string): Promise<void> => {
   try {
@@ -10,6 +11,7 @@ export default async (payload: IPayload, dsn: string): Promise<void> => {
       },
       body: JSON.stringify(payload),
     });
+    sendCached(dsn);
   } catch (error) {
     saveCrime(payload);
   }

--- a/src/apis/sendVisits.ts
+++ b/src/apis/sendVisits.ts
@@ -1,7 +1,7 @@
-export default (dsn: string): void => {
+export default async (dsn: string): Promise<void> => {
   try {
     if (dsn === '') return;
-    fetch(`${dsn}/visits`, {
+    await fetch(`${dsn}/visits`, {
       method: 'POST',
     });
   } catch (error) {

--- a/src/caching/saveCrime.ts
+++ b/src/caching/saveCrime.ts
@@ -1,0 +1,10 @@
+import { IPayload } from '../handlers/type';
+
+const saveCrime = (payload: IPayload): void => {
+  const localError = localStorage.getItem('crime');
+  const errorArr = localError !== null ? JSON.parse(localError) : [];
+  errorArr.push(payload);
+  localStorage.setItem('crime', JSON.stringify(errorArr));
+};
+
+export default saveCrime;

--- a/src/caching/sendCached.ts
+++ b/src/caching/sendCached.ts
@@ -1,0 +1,20 @@
+import { IPayload } from '../handlers/type';
+
+const sendCached = async (dsn: string): Promise<void> => {
+  const localError = localStorage.getItem('crime');
+  if (localError === null) return;
+  localStorage.removeItem('crime');
+  const cachedCrimes: IPayload[] = JSON.parse(localError);
+  try {
+    await fetch(`${dsn}/crimes`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(cachedCrimes),
+    });
+    // eslint-disable-next-line no-empty
+  } catch (error) {}
+};
+
+export default sendCached;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import sendVisits from './apis/sendEngagement';
+import sendVisits from './apis/sendVisits';
 import onErrorHandler from './handlers/onError';
 import onUnhandledRejection from './handlers/onUnhandledRejection';
 import onManualError from './handlers/onManualError';


### PR DESCRIPTION
### 구현의도
- visits api 수정
   visits api에 비동기 처리가 적용되지 않아 에러를 발생시키는 오류를 수정했습니다.

- 캐싱 기능 추가
   - 캐시 저장
     요청이 실패하면 localStorage에 stringify된 배열로 crimes를 저장합니다.
      localStorage에서 crimes를 찾아 있으면 parse후 배열에 추가해 다시 stringify된 배열을 저장하도록 구현했습니다.
  - 캐싱된 crime 전송
     새로 발생한 crime이 전송 성공했을 때, 캐싱된 crimes를 전송하도록 구현했습니다.
     캐싱된 crimes는 전송 성공 여부와 관련 없이 삭제되도록 구현했습니다.

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
